### PR TITLE
Added support of static props v10, v11

### DIFF
--- a/Assets/Code/Read/BSPFile.cs
+++ b/Assets/Code/Read/BSPFile.cs
@@ -518,7 +518,7 @@ namespace uSrcTools
 				{
 				case SourceBSPStructs.GAMELUMP_STATIC_PROPS:
 					Debug.Log ("Static props version is "+gl.version);
-					if(gl.version<10)
+					if(gl.version<12) //12 not released yet
 						ParseStaticProps(gl);
 					break;
 				}
@@ -596,8 +596,16 @@ namespace uSrcTools
 					//prop.DisableX360=br.ReadBoolean();
 					br.BaseStream.Seek(4,SeekOrigin.Current);
 				}
+                if (gl.version >= 10)
+                {
+                    prop.FlagsEx = br.ReadInt32();
+                }
+                if (gl.version >= 11)
+                {
+                    prop.UniformScale = br.ReadSingle();
+                }
 
-				temp[i]=prop;
+                temp[i]=prop;
 			}
 			
 			return temp;

--- a/Assets/Code/Read/SourceBSPStructs.cs
+++ b/Assets/Code/Read/SourceBSPStructs.cs
@@ -353,13 +353,15 @@ namespace uSrcTools
 		public byte   minGPULevel;
 		public byte   maxGPULevel;
 		public Color32 diffuseModulation;
-		/*// since v7
+        /*// since v7
 		public Color32         DiffuseModulation; // per instance color and alpha modulation
-		// since v10
-		public float           unknown; 
-		*/
-		// since v9
-		public bool            DisableX360;     // if true, don't show on XBox 360
+        */
+        // since v10
+        public int FlagsEx;
+        // since v11
+        public float UniformScale;      // Prop scale
+        // since v9
+        public bool            DisableX360;     // if true, don't show on XBox 360
 		//3 unknown bytes
 	}
 }


### PR DESCRIPTION
EN: now it able to load csgo static props (v10-11).

RU: теперь оно умеет грузить пропы версий 10-11 для ксго.
![uSrcTools](https://user-images.githubusercontent.com/22983870/56096048-8c4ae980-5efc-11e9-80e7-88ede4fc2c57.png)
