### PR TITLE
NET 4.0 material path fix

### DIFF
--- a/Assets/Code/Read/SourceBSPLoader.cs
+++ b/Assets/Code/Read/SourceBSPLoader.cs
@@ -686,6 +686,8 @@ namespace uSrcTools
 						materialName = materialName.Replace("maps/" + Test.Inst.mapName + "/", "");
 					      }
 					   }
+					   
+					  materialName = materialName.Replace('ı', 'i'); // switching to NET 4.0 or WebGL causes i letters to be replaced by ı for some computers which means missing texture
 					}
 
 					


### PR DESCRIPTION
My computer on 4.0 was replacing i letters on material path with ı which caused missing textures, so i put my fix here for others who potentially might experience this issue